### PR TITLE
Add static instance create

### DIFF
--- a/src/Resolver/InstanceCreator.php
+++ b/src/Resolver/InstanceCreator.php
@@ -22,6 +22,14 @@ final class InstanceCreator
     /**
      * @param class-string $className
      */
+    public static function create(string $className): ?object
+    {
+        return (new self())->createByClassName($className);
+    }
+
+    /**
+     * @param class-string $className
+     */
     public function createByClassName(string $className): ?object
     {
         if (class_exists($className)) {

--- a/tests/Unit/InstanceCreatorTest.php
+++ b/tests/Unit/InstanceCreatorTest.php
@@ -21,6 +21,13 @@ final class InstanceCreatorTest extends TestCase
         self::assertEquals(new ClassWithoutDependencies(), $actual);
     }
 
+    public function test_static_create_with_dependencies(): void
+    {
+        $actual = InstanceCreator::create(ClassWithObjectDependencies::class);
+
+        self::assertEquals(new ClassWithObjectDependencies(new Person()), $actual);
+    }
+
     public function test_without_dependencies(): void
     {
         $resolver = new InstanceCreator();

--- a/tests/Unit/InstanceCreatorTest.php
+++ b/tests/Unit/InstanceCreatorTest.php
@@ -14,6 +14,13 @@ use PHPUnit\Framework\TestCase;
 
 final class InstanceCreatorTest extends TestCase
 {
+    public function test_static_create_without_dependencies(): void
+    {
+        $actual = InstanceCreator::create(ClassWithoutDependencies::class);
+
+        self::assertEquals(new ClassWithoutDependencies(), $actual);
+    }
+
     public function test_without_dependencies(): void
     {
         $resolver = new InstanceCreator();


### PR DESCRIPTION
## 📚 Description

Allow a static shortcut call to instantiate a class by its name where there is no need for mapping interfaces

## 🔖 Changes

- Add `InstanceCreator::create()`
