### PR TITLE
Rename mappingInterfaces to bindings

### DIFF
--- a/src/Resolver/DependencyResolver.php
+++ b/src/Resolver/DependencyResolver.php
@@ -89,14 +89,14 @@ final class DependencyResolver
      */
     private function resolveClass(string $paramTypeName): mixed
     {
-        /** @var mixed $mappedClass */
-        $mappedClass = $this->bindings[$paramTypeName] ?? null;
-        if (is_callable($mappedClass)) {
-            return $mappedClass();
+        /** @var mixed $bindedClass */
+        $bindedClass = $this->bindings[$paramTypeName] ?? null;
+        if (is_callable($bindedClass)) {
+            return $bindedClass();
         }
 
-        if (is_object($mappedClass)) {
-            return $mappedClass;
+        if (is_object($bindedClass)) {
+            return $bindedClass;
         }
 
         $reflection = $this->resolveReflectionClass($paramTypeName);

--- a/src/Resolver/DependencyResolver.php
+++ b/src/Resolver/DependencyResolver.php
@@ -89,14 +89,14 @@ final class DependencyResolver
      */
     private function resolveClass(string $paramTypeName): mixed
     {
-        /** @var mixed $bindedClass */
-        $bindedClass = $this->bindings[$paramTypeName] ?? null;
-        if (is_callable($bindedClass)) {
-            return $bindedClass();
+        /** @var mixed $bindClass */
+        $bindClass = $this->bindings[$paramTypeName] ?? null;
+        if (is_callable($bindClass)) {
+            return $bindClass();
         }
 
-        if (is_object($bindedClass)) {
-            return $bindedClass;
+        if (is_object($bindClass)) {
+            return $bindClass;
         }
 
         $reflection = $this->resolveReflectionClass($paramTypeName);

--- a/src/Resolver/DependencyResolver.php
+++ b/src/Resolver/DependencyResolver.php
@@ -15,10 +15,10 @@ use function is_object;
 final class DependencyResolver
 {
     /**
-     * @param array<class-string,class-string|callable|object> $mappingInterfaces
+     * @param array<class-string,class-string|callable|object> $bindings
      */
     public function __construct(
-        private array $mappingInterfaces = [],
+        private array $bindings = [],
     ) {
     }
 
@@ -90,7 +90,7 @@ final class DependencyResolver
     private function resolveClass(string $paramTypeName): mixed
     {
         /** @var mixed $mappedClass */
-        $mappedClass = $this->mappingInterfaces[$paramTypeName] ?? null;
+        $mappedClass = $this->bindings[$paramTypeName] ?? null;
         if (is_callable($mappedClass)) {
             return $mappedClass();
         }
@@ -120,7 +120,7 @@ final class DependencyResolver
         }
 
         /** @var mixed $concreteClass */
-        $concreteClass = $this->mappingInterfaces[$reflection->getName()] ?? null;
+        $concreteClass = $this->bindings[$reflection->getName()] ?? null;
 
         if ($concreteClass !== null) {
             /** @var class-string $concreteClass */

--- a/src/Resolver/InstanceCreator.php
+++ b/src/Resolver/InstanceCreator.php
@@ -12,10 +12,10 @@ final class InstanceCreator
     private array $cachedDependencies = [];
 
     /**
-     * @param array<class-string,class-string|callable|object> $mappingInterfaces
+     * @param array<class-string, class-string|callable|object> $bindings
      */
     public function __construct(
-        private array $mappingInterfaces = [],
+        private array $bindings = [],
     ) {
     }
 
@@ -42,7 +42,7 @@ final class InstanceCreator
     {
         if ($this->dependencyResolver === null) {
             $this->dependencyResolver = new DependencyResolver(
-                $this->mappingInterfaces,
+                $this->bindings,
             );
         }
 


### PR DESCRIPTION
## 📚 Description

Similar as we adopted in the [gacela-project/router](https://github.com/gacela-project/router/blob/main/src/Router/Bindings.php) repo.

## 🔖 Changes

- Rename `$mappingInterfaces` to `$bindings`

## 💡 Follow up idea

We could apply a similar rename in the gacela repo: https://github.com/gacela-project/gacela/blob/main/src/Framework/Bootstrap/GacelaConfig.php#L141 
