### PR TITLE
Allow set instance by id

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Gacela\Container;
 
-use Psr\Container\ContainerInterface;
+use Closure;
+use Gacela\Container\Exception\ContainerException;
+use SplObjectStorage;
 
+use function count;
+use function is_array;
 use function is_callable;
 use function is_object;
 
@@ -16,34 +20,148 @@ final class Container implements ContainerInterface
     /** @var array<class-string,list<mixed>> */
     private array $cachedDependencies = [];
 
+    /** @var array<string,mixed> */
+    private array $instances = [];
+
+    private SplObjectStorage $factoryInstances;
+
+    private SplObjectStorage $protectedInstances;
+
+    /** @var array<string,bool> */
+    private array $frozenInstances = [];
+
+    private ?string $currentlyExtending = null;
+
     /**
      * @param array<class-string, class-string|callable|object> $bindings
+     * @param array<string, list<Closure>> $instancesToExtend
      */
     public function __construct(
         private array $bindings = [],
+        private array $instancesToExtend = [],
     ) {
+        $this->factoryInstances = new SplObjectStorage();
+        $this->protectedInstances = new SplObjectStorage();
     }
 
     /**
      * @param class-string $className
      */
-    public static function create(string $className): ?object
+    public static function create(string $className): mixed
     {
         return (new self())->get($className);
     }
 
     public function has(string $id): bool
     {
-        return is_object($this->get($id));
+        return isset($this->instances[$id]);
+    }
+
+    public function set(string $id, mixed $instance): void
+    {
+        if (isset($this->frozenInstances[$id])) {
+            throw ContainerException::instanceFrozen($id);
+        }
+
+        $this->instances[$id] = $instance;
+
+        if ($this->currentlyExtending === $id) {
+            return;
+        }
+
+        $this->extendService($id);
     }
 
     /**
      * @param class-string|string $id
      */
-    public function get(string $id): ?object
+    public function get(string $id): mixed
     {
-        if (isset($this->bindings[$id])) {
-            $binding = $this->bindings[$id];
+        if ($this->has($id)) {
+            return $this->getInstance($id);
+        }
+
+        return $this->createInstance($id);
+    }
+
+    public function factory(Closure $instance): Closure
+    {
+        $this->factoryInstances->attach($instance);
+
+        return $instance;
+    }
+
+    public function remove(string $id): void
+    {
+        unset(
+            $this->instances[$id],
+            $this->frozenInstances[$id]
+        );
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    public function extend(string $id, Closure $instance): Closure
+    {
+        if (!$this->has($id)) {
+            $this->extendLater($id, $instance);
+
+            return $instance;
+        }
+
+        if (isset($this->frozenInstances[$id])) {
+            throw ContainerException::instanceFrozen($id);
+        }
+
+        if (is_object($this->instances[$id]) && isset($this->protectedInstances[$this->instances[$id]])) {
+            throw ContainerException::instanceProtected($id);
+        }
+
+        $factory = $this->instances[$id];
+        $extended = $this->generateExtendedInstance($instance, $factory);
+        $this->set($id, $extended);
+
+        return $extended;
+    }
+
+    public function protect(Closure $instance): Closure
+    {
+        $this->protectedInstances->attach($instance);
+
+        return $instance;
+    }
+
+    private function getInstance(string $id): mixed
+    {
+        $this->frozenInstances[$id] = true;
+
+        if (!is_object($this->instances[$id])
+            || isset($this->protectedInstances[$this->instances[$id]])
+            || !method_exists($this->instances[$id], '__invoke')
+        ) {
+            return $this->instances[$id];
+        }
+
+        if (isset($this->factoryInstances[$this->instances[$id]])) {
+            return $this->instances[$id]($this);
+        }
+
+        $rawService = $this->instances[$id];
+
+        /** @psalm-suppress InvalidFunctionCall */
+        $this->instances[$id] = $rawService($this);
+
+        /** @var mixed $resolvedService */
+        $resolvedService = $this->instances[$id];
+
+        return $resolvedService;
+    }
+
+    private function createInstance(string $class): ?object
+    {
+        if (isset($this->bindings[$class])) {
+            $binding = $this->bindings[$class];
             if (is_callable($binding)) {
                 /** @var mixed $binding */
                 $binding = $binding();
@@ -58,8 +176,8 @@ final class Container implements ContainerInterface
             }
         }
 
-        if (class_exists($id)) {
-            return $this->instantiateClass($id);
+        if (class_exists($class)) {
+            return $this->instantiateClass($class);
         }
 
         return null;
@@ -84,6 +202,15 @@ final class Container implements ContainerInterface
         return null;
     }
 
+    private function extendLater(string $id, Closure $instance): void
+    {
+        if (!isset($this->instancesToExtend[$id])) {
+            $this->instancesToExtend[$id] = [];
+        }
+
+        $this->instancesToExtend[$id][] = $instance;
+    }
+
     private function getDependencyResolver(): DependencyResolver
     {
         if ($this->dependencyResolver === null) {
@@ -93,5 +220,47 @@ final class Container implements ContainerInterface
         }
 
         return $this->dependencyResolver;
+    }
+
+    /**
+     * @psalm-suppress MissingClosureReturnType,MixedAssignment
+     */
+    private function generateExtendedInstance(Closure $instance, mixed $factory): Closure
+    {
+        if (is_callable($factory)) {
+            return static function (self $container) use ($instance, $factory) {
+                $r1 = $factory($container);
+                $r2 = $instance($r1, $container);
+
+                return $r2 ?? $r1;
+            };
+        }
+
+        if (is_object($factory) || is_array($factory)) {
+            return static function (self $container) use ($instance, $factory) {
+                $r = $instance($factory, $container);
+
+                return $r ?? $factory;
+            };
+        }
+
+        throw ContainerException::instanceNotExtendable();
+    }
+
+    private function extendService(string $id): void
+    {
+        if (!isset($this->instancesToExtend[$id]) || count($this->instancesToExtend[$id]) === 0) {
+            return;
+        }
+        $this->currentlyExtending = $id;
+
+        foreach ($this->instancesToExtend[$id] as $instance) {
+            $extended = $this->extend($id, $instance);
+        }
+
+        unset($this->instancesToExtend[$id]);
+        $this->currentlyExtending = null;
+
+        $this->set($id, $extended);
     }
 }

--- a/src/Container/ContainerInterface.php
+++ b/src/Container/ContainerInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Container;
+
+use Closure;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
+
+interface ContainerInterface extends PsrContainerInterface
+{
+    /**
+     * Get the resolved value of the instance.
+     * Unless it is protected, in such a case it will get the raw instance as it was set.
+     */
+    public function get(string $id): mixed;
+
+    /**
+     * Check if an instance exists.
+     */
+    public function has(string $id): bool;
+
+    /**
+     * Set a new instance. You cannot override an existing instance, but you can extend it.
+     */
+    public function set(string $id, mixed $instance): void;
+
+    /**
+     * Remove a known instance.
+     */
+    public function remove(string $id): void;
+
+    /**
+     * Ensure the instance is returning a new instance everytime.
+     */
+    public function factory(Closure $instance): object;
+
+    /**
+     * Extend the functionality of an instance, even before it is defined.
+     */
+    public function extend(string $id, Closure $instance): Closure;
+
+    /**
+     * Protect an instance to be resolved. A protected instance cannot be extended.
+     */
+    public function protect(Closure $instance): object;
+}

--- a/src/Container/Exception/ContainerException.php
+++ b/src/Container/Exception/ContainerException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Container\Exception;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+final class ContainerException extends Exception implements ContainerExceptionInterface
+{
+    public static function instanceNotExtendable(): self
+    {
+        return new self('The passed instance is not extendable.');
+    }
+
+    public static function instanceFrozen(string $id): self
+    {
+        return new self("The instance '{$id}' is frozen and cannot be extendable.");
+    }
+
+    public static function instanceProtected(string $id): self
+    {
+        return new self("The instance '{$id}' is protected and cannot be extendable.");
+    }
+}

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace GacelaTest\Unit;
 
+use ArrayObject;
 use Gacela\Container\Container;
+use Gacela\Container\Exception\ContainerException;
 use GacelaTest\Fake\ClassWithInterfaceDependencies;
 use GacelaTest\Fake\ClassWithObjectDependencies;
 use GacelaTest\Fake\ClassWithoutDependencies;
@@ -73,14 +75,6 @@ final class ContainerTest extends TestCase
         $actual = $container->has(InexistentClass::class);
 
         self::assertFalse($actual);
-    }
-
-    public function test_container_has_class(): void
-    {
-        $container = new Container();
-        $actual = $container->has(Person::class);
-
-        self::assertTrue($actual);
     }
 
     public function test_resolve_object_from_interface(): void
@@ -152,5 +146,300 @@ final class ContainerTest extends TestCase
         $resolvedPerson = $container->get(PersonInterface::class);
 
         self::assertEquals($resolvedPerson, new Person());
+    }
+
+    public function test_get_non_existing_service(): void
+    {
+        $container = new Container();
+
+        self::assertNull($container->get('unknown-service_name'));
+    }
+
+    public function test_has_service(): void
+    {
+        $container = new Container();
+        $container->set('service_name', 'value');
+
+        self::assertTrue($container->has('service_name'));
+        self::assertFalse($container->has('unknown-service_name'));
+    }
+
+    public function test_remove_existing_service(): void
+    {
+        $container = new Container();
+        $container->set('service_name', 'value');
+        $container->remove('service_name');
+
+        self::assertNull($container->get('service_name'));
+    }
+
+    public function test_resolve_service_as_raw_string(): void
+    {
+        $container = new Container();
+        $container->set('service_name', 'value');
+
+        $resolvedService = $container->get('service_name');
+        self::assertSame('value', $resolvedService);
+
+        $cachedResolvedService = $container->get('service_name');
+        self::assertSame('value', $cachedResolvedService);
+    }
+
+    public function test_resolve_service_as_function(): void
+    {
+        $container = new Container();
+        $container->set('service_name', static fn () => 'value');
+
+        $resolvedService = $container->get('service_name');
+        self::assertSame('value', $resolvedService);
+
+        $cachedResolvedService = $container->get('service_name');
+        self::assertSame('value', $cachedResolvedService);
+    }
+
+    public function test_resolve_service_as_callable_class(): void
+    {
+        $container = new Container();
+        $container->set(
+            'service_name',
+            new class() {
+                public function __invoke(): string
+                {
+                    return 'value';
+                }
+            },
+        );
+
+        $resolvedService = $container->get('service_name');
+        self::assertSame('value', $resolvedService);
+
+        $cachedResolvedService = $container->get('service_name');
+        self::assertSame('value', $cachedResolvedService);
+    }
+
+    public function test_resolve_non_factory_service_with_random(): void
+    {
+        $container = new Container();
+        $container->set(
+            'service_name',
+            static fn () => 'value_' . random_int(0, PHP_INT_MAX),
+        );
+
+        self::assertSame(
+            $container->get('service_name'),
+            $container->get('service_name'),
+        );
+    }
+
+    public function test_resolve_factory_service_with_random(): void
+    {
+        $container = new Container();
+        $container->set(
+            'service_name',
+            $container->factory(
+                static fn () => 'value_' . random_int(0, PHP_INT_MAX),
+            ),
+        );
+
+        self::assertNotSame(
+            $container->get('service_name'),
+            $container->get('service_name'),
+        );
+    }
+
+    public function test_extend_existing_callable_service(): void
+    {
+        $container = new Container();
+        $container->set('n3', 3);
+        $container->set('service_name', static fn () => new ArrayObject([1, 2]));
+
+        $container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject, Container $container) {
+                $arrayObject->append($container->get('n3'));
+                return $arrayObject;
+            },
+        );
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
+        );
+
+        /** @var ArrayObject $actual */
+        $actual = $container->get('service_name');
+
+        self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
+    }
+
+    public function test_extend_existing_object_service(): void
+    {
+        $container = new Container();
+        $container->set('n3', 3);
+        $container->set('service_name', new ArrayObject([1, 2]));
+
+        $container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject, Container $container) {
+                $arrayObject->append($container->get('n3'));
+                return $arrayObject;
+            },
+        );
+
+        $container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject): void {
+                $arrayObject->append(4);
+            },
+        );
+
+        /** @var ArrayObject $actual */
+        $actual = $container->get('service_name');
+
+        self::assertEquals(new ArrayObject([1, 2, 3, 4]), $actual);
+    }
+
+    public function test_extend_existing_array_service(): void
+    {
+        $container = new Container();
+        $container->set('service_name', [1, 2]);
+
+        $container->extend(
+            'service_name',
+            static function (array $arrayObject): array {
+                $arrayObject[] = 3;
+                return $arrayObject;
+            },
+        );
+
+        $container->extend(
+            'service_name',
+            static function (array &$arrayObject): void {
+                $arrayObject[] = 4;
+            },
+        );
+
+        /** @var ArrayObject $actual */
+        $actual = $container->get('service_name');
+
+        self::assertEquals([1, 2, 3, 4], $actual);
+    }
+
+    public function test_extend_non_existing_service(): void
+    {
+        $container = new Container();
+        $container->extend('service_name', static fn () => '');
+
+        self::assertNull($container->get('service_name'));
+    }
+
+    public function test_service_not_extendable(): void
+    {
+        $container = new Container();
+        $container->set('service_name', 'raw string');
+
+        $this->expectExceptionObject(ContainerException::instanceNotExtendable());
+        $container->extend('service_name', static fn (string $str) => $str);
+    }
+
+    public function test_extend_existing_used_object_service_is_allowed(): void
+    {
+        $container = new Container();
+        $container->set('service_name', new ArrayObject([1, 2]));
+        $container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::instanceFrozen('service_name'));
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
+        );
+    }
+
+    public function test_extend_existing_used_callable_service_then_error(): void
+    {
+        $container = new Container();
+        $container->set('service_name', static fn () => new ArrayObject([1, 2]));
+        $container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::instanceFrozen('service_name'));
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
+        );
+    }
+
+    public function test_extend_later_existing_frozen_object_service_then_error(): void
+    {
+        $container = new Container();
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
+        );
+
+        $container->set('service_name', new ArrayObject([1, 2]));
+        $container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::instanceFrozen('service_name'));
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
+        );
+    }
+
+    public function test_extend_later_existing_frozen_callable_service_then_error(): void
+    {
+        $container = new Container();
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(3),
+        );
+
+        $container->set('service_name', static fn () => new ArrayObject([1, 2]));
+        $container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::instanceFrozen('service_name'));
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject->append(4),
+        );
+    }
+
+    public function test_set_existing_frozen_service(): void
+    {
+        $container = new Container();
+        $container->set('service_name', static fn () => new ArrayObject([1, 2]));
+        $container->get('service_name'); // and get frozen
+
+        $this->expectExceptionObject(ContainerException::instanceFrozen('service_name'));
+        $container->set('service_name', static fn () => new ArrayObject([3]));
+    }
+
+    public function test_protect_service_is_not_resolved(): void
+    {
+        $container = new Container();
+        $service = static fn () => 'value';
+        $container->set('service_name', $container->protect($service));
+
+        self::assertSame($service, $container->get('service_name'));
+    }
+
+    public function test_protect_service_cannot_be_extended(): void
+    {
+        $container = new Container();
+        $container->set(
+            'service_name',
+            $container->protect(static fn () => new ArrayObject([1, 2])),
+        );
+
+        $this->expectExceptionObject(ContainerException::instanceProtected('service_name'));
+
+        $container->extend(
+            'service_name',
+            static fn (ArrayObject $arrayObject) => $arrayObject,
+        );
     }
 }


### PR DESCRIPTION
## 📚 Description

Gacela has its own internal Container for each individual/different module:
https://github.com/gacela-project/gacela/blob/main/src/Framework/Container/Container.php

The goal is to move that logic to this isolated `Container` repo.

## 🔖 Changes

This is the Container's API:
```php
interface ContainerInterface extends PsrContainerInterface
{
    /**
     * Get the resolved value of the instance.
     * Unless it is protected, in such a case it will get the raw instance as it was set.
     */
    public function get(string $id): mixed;

    /**
     * Check if an instance exists.
     */
    public function has(string $id): bool;

    /**
     * Set a new instance. You cannot override an existing instance, but you can extend it.
     */
    public function set(string $id, mixed $instance): void;

    /**
     * Remove a known instance.
     */
    public function remove(string $id): void;

    /**
     * Ensure the instance is returning a new instance everytime.
     */
    public function factory(Closure $instance): object;

    /**
     * Extend the functionality of an instance, even before it is defined.
     */
    public function extend(string $id, Closure $instance): Closure;

    /**
     * Protect an instance to be resolved. A protected instance cannot be extended.
     */
    public function protect(Closure $instance): object;
}
```
