### PR TITLE
Improved error message when no concrete binded class was found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improved error message when no concrete binded class was found
+
 ## 0.4.0
 ### 2023-04-27
 

--- a/src/Container/Exception/DependencyNotFoundException.php
+++ b/src/Container/Exception/DependencyNotFoundException.php
@@ -12,8 +12,11 @@ final class DependencyNotFoundException extends RuntimeException implements NotF
     public static function mapNotFoundForClassName(string $className): self
     {
         $message = <<<TXT
-Did you forget to map this interface to a concrete class? No concrete class was found that implements:
-{$className}
+No concrete class was found that implements:
+"{$className}"
+Did you forget to bind this interface to a concrete class?
+
+You might find some help here: https://gacela-project.com/docs/bootstrap/#bindings 
 TXT;
         return new self($message);
     }


### PR DESCRIPTION
## 🔖 Changes

- Change the error message from `DependencyNotFoundException`
