### PR TITLE
Fix factory service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Container performance avoid reflection
+- Fix factory services
 
 ## 0.6.1
 ### 2024-07-06

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -141,6 +141,11 @@ class Container implements ContainerInterface
         $extended = $this->generateExtendedInstance($instance, $factory);
         $this->set($id, $extended);
 
+        if (is_object($factory) && isset($this->factoryInstances[$factory])) {
+            $this->factoryInstances->detach($factory);
+            $this->factoryInstances->attach($extended);
+        }
+
         return $extended;
     }
 

--- a/tests/Unit/ClassContainerTest.php
+++ b/tests/Unit/ClassContainerTest.php
@@ -271,6 +271,36 @@ final class ClassContainerTest extends TestCase
         );
     }
 
+    public function test_extend_existing_factory_service(): void
+    {
+        $container = new Container();
+        $container->set('n3', 3);
+        $container->set(
+            'service_name',
+            $container->factory(
+                static fn () => new ArrayObject([1, 2]),
+            ),
+        );
+
+        $container->extend(
+            'service_name',
+            static function (ArrayObject $arrayObject, Container $container): ArrayObject {
+                $arrayObject->append($container->get('n3'));
+
+                return $arrayObject;
+            },
+        );
+
+        /** @var ArrayObject $first */
+        $first = $container->get('service_name');
+        /** @var ArrayObject $second */
+        $second = $container->get('service_name');
+
+        self::assertEquals(new ArrayObject([1, 2, 3]), $first);
+        self::assertEquals(new ArrayObject([1, 2, 3]), $second);
+        self::assertNotSame($first, $second);
+    }
+
     public function test_extend_existing_callable_service(): void
     {
         $container = new Container();


### PR DESCRIPTION
## 📚 Description

Tests revealed that extending a service flagged as a factory caused the container to forget the factory behavior. The fix reattaches the factory marker after applying the extension.

## 🔖 Changes

- Preserve factory status when a service is extended so repeated calls create new instances
- Add unit test ensuring factory services remain factories after extension
