### PR TITLE
 Improve container performance and developer experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add fuzzy service name suggestions to error messages for better typo detection
+- Add alias resolution caching for improved performance
+- Add getStats() method for container debugging and performance monitoring
 - Improve error messages with actionable suggestions for easier debugging
 - Add circular dependency detection with helpful error messages
 - Optimize callableKey() to use spl_object_id() instead of md5+var_export

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ $container->warmUp([
 
 ## Error Handling
 
-The container provides clear, actionable error messages:
+The container provides clear, actionable error messages with helpful suggestions:
 
 ### Missing Type Hint
 ```
@@ -299,6 +299,19 @@ Scalar types (string, int, float, bool, array) cannot be auto-resolved.
 
 Provide a default value for the parameter:
   public function __construct(string $param = 'default') { ... }
+```
+
+### Service Not Found (with suggestions)
+```
+No concrete class was found that implements:
+"App\LogerInterface"
+Did you forget to bind this interface to a concrete class?
+
+Did you mean one of these?
+  - App\LoggerInterface
+  - App\Service\LoggerInterface
+
+You might find some help here: https://gacela-project.com/docs/bootstrap/#bindings
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ if ($container->isFrozen('logger')) {
 
 // Get all bindings
 $bindings = $container->getBindings();
+
+// Get comprehensive statistics
+$stats = $container->getStats();
+/*
+[
+    'registered_services' => 42,
+    'frozen_services' => 15,
+    'factory_services' => 3,
+    'bindings' => 8,
+    'cached_dependencies' => 25,
+    'memory_usage' => '2.34 MB'
+]
+*/
 ```
 
 ### Performance Optimization
@@ -217,6 +230,7 @@ $db2 = $container->get(PDO::class);  // Same instance
 | `getBindings(): array` | Get all bindings |
 | `warmUp(array $classNames): void` | Pre-resolve dependencies |
 | `alias(string $alias, string $id): void` | Create an alias for a service (with caching) |
+| `getStats(): array` | Get container statistics for debugging and performance monitoring |
 
 ### Static Methods
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ $container->warmUp([
 $service = $container->get(UserService::class); // Faster!
 ```
 
+### Service Aliasing
+
+Create multiple names for the same service:
+
+```php
+// Create an alias
+$container->alias('db', PDO::class);
+
+// Access via alias or original name
+$db1 = $container->get('db');        // Same instance
+$db2 = $container->get(PDO::class);  // Same instance
+
+// Alias resolution is cached for optimal performance
+```
+
 ## API Reference
 
 ### Container Methods
@@ -201,6 +216,7 @@ $service = $container->get(UserService::class); // Faster!
 | `isFrozen(string $id): bool` | Check if service is frozen |
 | `getBindings(): array` | Get all bindings |
 | `warmUp(array $classNames): void` | Pre-resolve dependencies |
+| `alias(string $alias, string $id): void` | Create an alias for a service (with caching) |
 
 ### Static Methods
 

--- a/src/Container/AliasRegistry.php
+++ b/src/Container/AliasRegistry.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Gacela\Container;
 
 /**
- * Manages service name aliases.
+ * Manages service name aliases with resolution caching.
  * Allows accessing the same service with multiple identifiers.
  */
 final class AliasRegistry
@@ -13,21 +13,33 @@ final class AliasRegistry
     /** @var array<string,string> */
     private array $aliases = [];
 
+    /** @var array<string,string> */
+    private array $resolvedCache = [];
+
     /**
      * Create an alias for a service.
      */
     public function add(string $alias, string $id): void
     {
         $this->aliases[$alias] = $id;
+        // Clear cached resolutions when aliases change
+        $this->resolvedCache = [];
     }
 
     /**
-     * Resolve an alias to its actual service ID.
+     * Resolve an alias to its actual service ID with caching.
      * Returns the input if no alias exists.
      */
     public function resolve(string $id): string
     {
-        return $this->aliases[$id] ?? $id;
+        if (isset($this->resolvedCache[$id])) {
+            return $this->resolvedCache[$id];
+        }
+
+        $resolved = $this->aliases[$id] ?? $id;
+        $this->resolvedCache[$id] = $resolved;
+
+        return $resolved;
     }
 
     /**

--- a/src/Container/DependencyCacheManager.php
+++ b/src/Container/DependencyCacheManager.php
@@ -7,6 +7,7 @@ namespace Gacela\Container;
 use Closure;
 
 use function class_exists;
+use function count;
 
 /**
  * Manages dependency resolution caching for performance optimization.
@@ -100,6 +101,24 @@ final class DependencyCacheManager
         }
 
         return null;
+    }
+
+    /**
+     * Get the number of cached dependency resolutions.
+     */
+    public function getCacheSize(): int
+    {
+        return count($this->cachedDependencies);
+    }
+
+    /**
+     * Get all cached class names.
+     *
+     * @return list<string>
+     */
+    public function getCachedClasses(): array
+    {
+        return array_keys($this->cachedDependencies);
     }
 
     private function getDependencyResolver(): DependencyResolver

--- a/src/Container/DependencyResolver.php
+++ b/src/Container/DependencyResolver.php
@@ -219,7 +219,14 @@ final class DependencyResolver
                     /** @var class-string $concreteClass */
                     $reflection = new ReflectionClass($concreteClass);
                 } else {
-                    throw DependencyNotFoundException::mapNotFoundForClassName($reflection->getName());
+                    $suggestions = FuzzyMatcher::findSimilar(
+                        $reflection->getName(),
+                        array_keys($this->bindings),
+                    );
+                    throw DependencyNotFoundException::mapNotFoundForClassName(
+                        $reflection->getName(),
+                        $suggestions,
+                    );
                 }
             }
 

--- a/src/Container/Exception/DependencyNotFoundException.php
+++ b/src/Container/Exception/DependencyNotFoundException.php
@@ -7,17 +7,32 @@ namespace Gacela\Container\Exception;
 use Psr\Container\NotFoundExceptionInterface;
 use RuntimeException;
 
+use function count;
+
 final class DependencyNotFoundException extends RuntimeException implements NotFoundExceptionInterface
 {
-    public static function mapNotFoundForClassName(string $className): self
+    /**
+     * @param list<string> $suggestions
+     */
+    public static function mapNotFoundForClassName(string $className, array $suggestions = []): self
     {
         $message = <<<TXT
 No concrete class was found that implements:
 "{$className}"
 Did you forget to bind this interface to a concrete class?
 
-You might find some help here: https://gacela-project.com/docs/bootstrap/#bindings 
 TXT;
+
+        if (count($suggestions) > 0) {
+            $message .= "\nDid you mean one of these?\n";
+            foreach ($suggestions as $suggestion) {
+                $message .= "  - {$suggestion}\n";
+            }
+            $message .= "\n";
+        }
+
+        $message .= 'You might find some help here: https://gacela-project.com/docs/bootstrap/#bindings';
+
         return new self($message);
     }
 }

--- a/src/Container/FuzzyMatcher.php
+++ b/src/Container/FuzzyMatcher.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gacela\Container;
+
+use function array_filter;
+use function array_map;
+use function array_slice;
+use function count;
+use function levenshtein;
+use function max;
+use function min;
+use function strlen;
+use function usort;
+
+/**
+ * Provides fuzzy matching for service names to suggest alternatives.
+ */
+final class FuzzyMatcher
+{
+    private const MAX_SUGGESTIONS = 3;
+    private const SIMILARITY_THRESHOLD = 0.6;
+
+    /**
+     * Find similar strings from a list of candidates.
+     *
+     * @param list<string> $candidates
+     *
+     * @return list<string>
+     */
+    public static function findSimilar(string $target, array $candidates): array
+    {
+        if (count($candidates) === 0) {
+            return [];
+        }
+
+        $scores = array_map(
+            static fn (string $candidate): array => [
+                'name' => $candidate,
+                'score' => self::calculateSimilarity($target, $candidate),
+            ],
+            $candidates,
+        );
+
+        // Sort by score descending
+        usort($scores, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+        // Filter by threshold and limit results
+        $filtered = array_filter(
+            $scores,
+            static fn (array $item): bool => $item['score'] >= self::SIMILARITY_THRESHOLD,
+        );
+
+        $suggestions = array_map(
+            static fn (array $item): string => $item['name'],
+            $filtered,
+        );
+
+        return array_slice($suggestions, 0, self::MAX_SUGGESTIONS);
+    }
+
+    /**
+     * Calculate similarity between two strings (0.0 to 1.0).
+     */
+    private static function calculateSimilarity(string $a, string $b): float
+    {
+        $maxLength = max(strlen($a), strlen($b));
+        if ($maxLength === 0) {
+            return 1.0;
+        }
+
+        $distance = levenshtein($a, $b);
+        if ($distance === -1) {
+            // Strings too long for levenshtein, use simple approach
+            return self::simpleSimilarity($a, $b);
+        }
+
+        return 1.0 - ($distance / $maxLength);
+    }
+
+    /**
+     * Fallback similarity calculation for very long strings.
+     */
+    private static function simpleSimilarity(string $a, string $b): float
+    {
+        $maxLength = max(strlen($a), strlen($b));
+        $minLength = min(strlen($a), strlen($b));
+
+        if ($maxLength === 0) {
+            return 1.0;
+        }
+
+        // Simple length-based similarity
+        return $minLength / $maxLength;
+    }
+}

--- a/tests/Unit/AliasRegistryTest.php
+++ b/tests/Unit/AliasRegistryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit;
+
+use Gacela\Container\AliasRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class AliasRegistryTest extends TestCase
+{
+    public function test_resolve_returns_original_when_no_alias(): void
+    {
+        $registry = new AliasRegistry();
+
+        $result = $registry->resolve('ServiceName');
+
+        self::assertSame('ServiceName', $result);
+    }
+
+    public function test_resolve_returns_alias_when_exists(): void
+    {
+        $registry = new AliasRegistry();
+        $registry->add('alias', 'ServiceName');
+
+        $result = $registry->resolve('alias');
+
+        self::assertSame('ServiceName', $result);
+    }
+
+    public function test_has_returns_false_when_alias_does_not_exist(): void
+    {
+        $registry = new AliasRegistry();
+
+        self::assertFalse($registry->has('nonexistent'));
+    }
+
+    public function test_has_returns_true_when_alias_exists(): void
+    {
+        $registry = new AliasRegistry();
+        $registry->add('alias', 'ServiceName');
+
+        self::assertTrue($registry->has('alias'));
+    }
+
+    public function test_resolve_uses_cache_on_repeated_calls(): void
+    {
+        $registry = new AliasRegistry();
+        $registry->add('alias', 'ServiceName');
+
+        // First call should populate cache
+        $result1 = $registry->resolve('alias');
+        // Second call should use cache
+        $result2 = $registry->resolve('alias');
+
+        self::assertSame('ServiceName', $result1);
+        self::assertSame('ServiceName', $result2);
+    }
+
+    public function test_adding_new_alias_clears_cache(): void
+    {
+        $registry = new AliasRegistry();
+        $registry->add('alias1', 'ServiceA');
+
+        // Populate cache
+        $registry->resolve('alias1');
+
+        // Add new alias should clear cache
+        $registry->add('alias2', 'ServiceB');
+
+        // Both should work correctly
+        self::assertSame('ServiceA', $registry->resolve('alias1'));
+        self::assertSame('ServiceB', $registry->resolve('alias2'));
+    }
+
+    public function test_resolve_caches_non_aliased_ids(): void
+    {
+        $registry = new AliasRegistry();
+
+        // First call
+        $result1 = $registry->resolve('DirectService');
+        // Second call should use cache
+        $result2 = $registry->resolve('DirectService');
+
+        self::assertSame('DirectService', $result1);
+        self::assertSame('DirectService', $result2);
+    }
+}

--- a/tests/Unit/ClassDependencyResolverTest.php
+++ b/tests/Unit/ClassDependencyResolverTest.php
@@ -86,4 +86,19 @@ final class ClassDependencyResolverTest extends TestCase
         $resolver = new DependencyResolver();
         $resolver->resolveDependencies(PersonWithoutParamType::class);
     }
+
+    public function test_missing_interface_with_suggestions(): void
+    {
+        $resolver = new DependencyResolver([
+            'GacelaTest\\Fake\\PersonInterfaceTypo' => Person::class,
+            'GacelaTest\\Fake\\PersonInterfce' => Person::class, // Close typo
+        ]);
+
+        try {
+            $resolver->resolveDependencies(ClassWithInterfaceDependencies::class);
+            self::fail('Expected DependencyNotFoundException to be thrown');
+        } catch (DependencyNotFoundException $e) {
+            self::assertStringContainsString('Did you mean one of these?', $e->getMessage());
+        }
+    }
 }

--- a/tests/Unit/ContainerStatsTest.php
+++ b/tests/Unit/ContainerStatsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit;
+
+use Gacela\Container\Container;
+use GacelaTest\Fake\ClassWithoutDependencies;
+use GacelaTest\Fake\Person;
+use PHPUnit\Framework\TestCase;
+
+final class ContainerStatsTest extends TestCase
+{
+    public function test_get_stats_returns_correct_structure(): void
+    {
+        $container = new Container();
+
+        $stats = $container->getStats();
+
+        self::assertArrayHasKey('registered_services', $stats);
+        self::assertArrayHasKey('frozen_services', $stats);
+        self::assertArrayHasKey('factory_services', $stats);
+        self::assertArrayHasKey('bindings', $stats);
+        self::assertArrayHasKey('cached_dependencies', $stats);
+        self::assertArrayHasKey('memory_usage', $stats);
+    }
+
+    public function test_stats_counts_registered_services(): void
+    {
+        $container = new Container();
+        $container->set('service1', new ClassWithoutDependencies());
+        $container->set('service2', new Person());
+
+        $stats = $container->getStats();
+
+        self::assertSame(2, $stats['registered_services']);
+    }
+
+    public function test_stats_counts_frozen_services(): void
+    {
+        $container = new Container();
+        $container->set('service1', static fn () => new ClassWithoutDependencies());
+        $container->set('service2', static fn () => new Person());
+
+        // Access service1 to freeze it
+        $container->get('service1');
+
+        $stats = $container->getStats();
+
+        self::assertSame(1, $stats['frozen_services']);
+    }
+
+    public function test_stats_counts_factory_services(): void
+    {
+        $container = new Container();
+        $container->set('factory1', $container->factory(static fn () => new ClassWithoutDependencies()));
+        $container->set('regular', static fn () => new Person());
+
+        $stats = $container->getStats();
+
+        self::assertSame(1, $stats['factory_services']);
+    }
+
+    public function test_stats_counts_bindings(): void
+    {
+        $container = new Container([
+            'InterfaceA' => 'ConcreteA',
+            'InterfaceB' => 'ConcreteB',
+        ]);
+
+        $stats = $container->getStats();
+
+        self::assertSame(2, $stats['bindings']);
+    }
+
+    public function test_stats_includes_memory_usage(): void
+    {
+        $container = new Container();
+
+        $stats = $container->getStats();
+
+        self::assertIsString($stats['memory_usage']);
+        self::assertMatchesRegularExpression('/^\d+(\.\d+)?\s+(B|KB|MB|GB)$/', $stats['memory_usage']);
+    }
+
+    public function test_stats_reflects_cached_dependencies_after_warmup(): void
+    {
+        $container = new Container();
+
+        // Before warmup
+        $statsBefore = $container->getStats();
+        self::assertSame(0, $statsBefore['cached_dependencies']);
+
+        // After warmup
+        $container->warmUp([ClassWithoutDependencies::class, Person::class]);
+        $statsAfter = $container->getStats();
+
+        self::assertSame(2, $statsAfter['cached_dependencies']);
+    }
+
+    public function test_stats_updates_after_container_operations(): void
+    {
+        $container = new Container();
+
+        $stats1 = $container->getStats();
+        self::assertSame(0, $stats1['registered_services']);
+
+        $container->set('service', new Person());
+
+        $stats2 = $container->getStats();
+        self::assertSame(1, $stats2['registered_services']);
+
+        $container->remove('service');
+
+        $stats3 = $container->getStats();
+        self::assertSame(0, $stats3['registered_services']);
+    }
+}

--- a/tests/Unit/FuzzyMatcherTest.php
+++ b/tests/Unit/FuzzyMatcherTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaTest\Unit;
+
+use Gacela\Container\FuzzyMatcher;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+final class FuzzyMatcherTest extends TestCase
+{
+    public function test_finds_exact_match(): void
+    {
+        $candidates = ['UserService', 'OrderService', 'PaymentService'];
+        $result = FuzzyMatcher::findSimilar('UserService', $candidates);
+
+        self::assertContains('UserService', $result);
+    }
+
+    public function test_finds_similar_names(): void
+    {
+        $candidates = ['UserService', 'OrderService', 'PaymentService'];
+        $result = FuzzyMatcher::findSimilar('UserServce', $candidates); // Typo
+
+        self::assertContains('UserService', $result);
+    }
+
+    public function test_finds_interface_vs_class(): void
+    {
+        $candidates = ['LoggerInterface', 'CacheInterface', 'UserInterface'];
+        $result = FuzzyMatcher::findSimilar('LogerInterface', $candidates); // Missing 'g'
+
+        self::assertContains('LoggerInterface', $result);
+    }
+
+    public function test_returns_empty_for_no_similar_matches(): void
+    {
+        $candidates = ['UserService', 'OrderService', 'PaymentService'];
+        $result = FuzzyMatcher::findSimilar('CompletelyDifferent', $candidates);
+
+        self::assertEmpty($result);
+    }
+
+    public function test_returns_empty_for_empty_candidates(): void
+    {
+        $result = FuzzyMatcher::findSimilar('UserService', []);
+
+        self::assertEmpty($result);
+    }
+
+    public function test_limits_suggestions_to_three(): void
+    {
+        $candidates = [
+            'UserService',
+            'UserServiceImpl',
+            'UserServiceInterface',
+            'UserServiceFactory',
+            'UserServiceProvider',
+        ];
+        $result = FuzzyMatcher::findSimilar('UserService', $candidates);
+
+        self::assertLessThanOrEqual(3, count($result));
+    }
+
+    public function test_prioritizes_closer_matches(): void
+    {
+        $candidates = ['UserService', 'UserServce', 'UserSrvice'];
+        $result = FuzzyMatcher::findSimilar('UserService', $candidates);
+
+        // Exact match should be first
+        self::assertSame('UserService', $result[0]);
+    }
+
+    public function test_handles_namespace_differences(): void
+    {
+        $candidates = [
+            'App\\Service\\LoggerInterface',
+            'App\\Service\\CacheInterface',
+            'App\\Service\\Logger',
+        ];
+        $result = FuzzyMatcher::findSimilar('App\\Service\\LogerInterface', $candidates);
+
+        self::assertContains('App\\Service\\LoggerInterface', $result);
+    }
+}


### PR DESCRIPTION
 This PR introduces three key improvements to the container

##  Fuzzy Service Name Suggestions

  When a service is not found, the container now suggests similar service names to help catch typos quickly:
  No concrete class was found that implements: "App\LogerInterface"
```
  Did you mean one of these?
    - App\LoggerInterface
    - App\Service\LoggerInterface
```
##  Alias Resolution Caching

  Service alias resolution is now cached, eliminating redundant lookups and improving performance for containers with heavy alias usage.

##   Container Statistics

  New getStats() method provides debugging and monitoring information:
```php
  $stats = $container->getStats();
  // Returns: registered_services, frozen_services, factory_services,
  //          bindings, cached_dependencies, memory_usage
  ```